### PR TITLE
pkg/util: fix handling of relative path to standard library

### DIFF
--- a/pkg/ast/Program.go
+++ b/pkg/ast/Program.go
@@ -582,7 +582,7 @@ func SearchPaths(base string) []string {
 	sp := make([]string, 0)
 
 	sp = append(sp, base)
-	sp = append(sp, "/usr/local/lib/geodelib")
+	sp = append(sp, util.StdLibDir())
 
 	for base != "/" && base != "." {
 		dir := filepath.Join(base, packagedir)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -63,6 +64,12 @@ func StdLibDir() string {
 	libpath := os.Getenv("GEODELIB")
 	if libpath == "" {
 		libpath = "/usr/local/lib/geodelib"
+	} else {
+		absPath, err := filepath.Abs(libpath)
+		if err != nil {
+			panic(fmt.Errorf("unable to locate absolute directory of standard library at %q", libpath))
+		}
+		libpath = absPath
 	}
 	return libpath
 }


### PR DESCRIPTION
Also, use util.StdLibDir() in ast.SearchPaths instead of
hardcoded /usr/local/lib/geodelib.

After this commit, it is possible to use
relative paths for the standard library:

	$ export GEODELIB=./lib/
	$ geode test
	Total: 23 / 23 tests ran succesfully