### PR TITLE
update to latest version of llir/llvm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/inspirer/textmapper v0.0.0-20181209132054-5280caf89d64 // indirect
 	github.com/kr/pretty v0.1.0
-	github.com/llir/llvm v0.3.0-pre4.0.20181210010959-63a2856a6873
+	github.com/llir/llvm v0.3.0-pre4.0.20181210021817-cba86447c61e
 	github.com/pkg/errors v0.8.0
 	github.com/sergi/go-diff v1.0.0
 	github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,20 @@
+module github.com/geode-lang/geode
+
+go 1.12
+
+require (
+	github.com/BurntSushi/toml v0.3.1
+	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
+	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
+	github.com/inspirer/textmapper v0.0.0-20181209132054-5280caf89d64 // indirect
+	github.com/kr/pretty v0.1.0
+	github.com/llir/llvm v0.3.0-pre4.0.20181210010959-63a2856a6873
+	github.com/pkg/errors v0.8.0
+	github.com/sergi/go-diff v1.0.0
+	github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0
+	github.com/tcnksm/go-input v0.0.0-20180404061846-548a7d7a8ee8
+	golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 // indirect
+	golang.org/x/sys v0.0.0-20181208175041-ad97f365e150 // indirect
+	golang.org/x/tools v0.0.0-20181207222222-4c874b978acb // indirect
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+)

--- a/pkg/ast/Accessable.go
+++ b/pkg/ast/Accessable.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir/value"
 )
 
 // Accessable is an interface implementable by

--- a/pkg/ast/Addressable.go
+++ b/pkg/ast/Addressable.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"github.com/geode-lang/geode/llvm/ir"
+	"github.com/llir/llvm/ir"
 )
 
 // Addressable is an interface implementable by

--- a/pkg/ast/ArrayNode.go
+++ b/pkg/ast/ArrayNode.go
@@ -84,12 +84,14 @@ func (n ArrayNode) Codegen(prog *Program) (value.Value, error) {
 
 	zero := constant.NewInt(types.I64, 0)
 	one := constant.NewInt(types.I64, 1)
-	arrayStart := block.NewGetElementPtr(alloca, zero, zero)
+	arrayStart := gep(alloca, zero, zero)
+	block.Insts = append(block.Insts, arrayStart)
 	offset := arrayStart
 
 	for i, val := range values {
 		if i > 0 {
-			offset = block.NewGetElementPtr(offset, one)
+			offset = gep(offset, one)
+			block.Insts = append(block.Insts, offset)
 		}
 
 		c, err := createTypeCast(prog, val, itemType)

--- a/pkg/ast/ArrayNode.go
+++ b/pkg/ast/ArrayNode.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir/constant"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 )
 
 // ArrayNode -

--- a/pkg/ast/ArrayNode.go
+++ b/pkg/ast/ArrayNode.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	gtypes "github.com/geode-lang/geode/pkg/types"
 	"github.com/llir/llvm/ir/constant"
 	"github.com/llir/llvm/ir/types"
 	"github.com/llir/llvm/ir/value"
@@ -59,15 +60,15 @@ func (n ArrayNode) Codegen(prog *Program) (value.Value, error) {
 		typ = types.NewPointer(values[0].Type())
 	}
 
-	itemType := typ.(*types.PointerType).Elem
+	itemType := typ.(*types.PointerType).ElemType
 
-	arrayType := types.NewArray(itemType, int64(n.Length))
+	arrayType := types.NewArray(uint64(n.Length), itemType)
 
 	// arrayLength := int64(itemType.ByteCount() * n.Length)
 	var alloca value.Value
 	// alloca = block.NewAlloca(arrayType)
 
-	length := constant.NewInt(int64(n.Length*arrayType.ByteCount()), types.I32)
+	length := constant.NewInt(types.I32, int64(n.Length*gtypes.ByteCount(arrayType)))
 
 	dyn, err := prog.NewRuntimeFunctionCall("xmalloc", length)
 	if err != nil {
@@ -81,8 +82,8 @@ func (n ArrayNode) Codegen(prog *Program) (value.Value, error) {
 
 	alloca = block.NewAlloca(arrayType)
 
-	zero := constant.NewInt(int64(0), types.I64)
-	one := constant.NewInt(int64(1), types.I64)
+	zero := constant.NewInt(types.I64, 0)
+	one := constant.NewInt(types.I64, 1)
 	arrayStart := block.NewGetElementPtr(alloca, zero, zero)
 	offset := arrayStart
 

--- a/pkg/ast/ArrayNode.go
+++ b/pkg/ast/ArrayNode.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	gtypes "github.com/geode-lang/geode/pkg/types"
+	"github.com/geode-lang/geode/pkg/gtypes"
 	"github.com/llir/llvm/ir/constant"
 	"github.com/llir/llvm/ir/types"
 	"github.com/llir/llvm/ir/value"

--- a/pkg/ast/Assignable.go
+++ b/pkg/ast/Assignable.go
@@ -1,8 +1,8 @@
 package ast
 
 import (
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 )
 
 // Assignable is an interface that a node can implement that

--- a/pkg/ast/AssignmentNode.go
+++ b/pkg/ast/AssignmentNode.go
@@ -3,8 +3,8 @@ package ast
 import (
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 )
 
 // AssignmentNode is a node that has an assignable and a value.

--- a/pkg/ast/BinaryNode.go
+++ b/pkg/ast/BinaryNode.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 )
 
 func createCmp(blk *ir.BasicBlock, i ir.IntPred, f ir.FloatPred, t types.Type, left, right value.Value) value.Value {

--- a/pkg/ast/BinaryNode.go
+++ b/pkg/ast/BinaryNode.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 
 	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/enum"
 	"github.com/llir/llvm/ir/types"
 	"github.com/llir/llvm/ir/value"
 )
 
-func createCmp(blk *ir.BasicBlock, i ir.IntPred, f ir.FloatPred, t types.Type, left, right value.Value) value.Value {
+func createCmp(blk *ir.BasicBlock, i enum.IPred, f enum.FPred, t types.Type, left, right value.Value) value.Value {
 
 	var val value.Value
 
@@ -26,14 +27,14 @@ func createCmp(blk *ir.BasicBlock, i ir.IntPred, f ir.FloatPred, t types.Type, l
 // CreateBinaryOp produces a geode binary op (just a wrapper around geode-lang/geode/llvm's binary instructions)
 func CreateBinaryOp(intstr, fltstr string, blk *ir.BasicBlock, t types.Type, left, right value.Value) value.Value {
 
-	var val *GeodeBinaryInstr
+	var val BinaryInstruction
 	if types.IsInt(t) {
 		val = NewGeodeBinaryInstr(intstr, left, right)
 	} else {
 		val = NewGeodeBinaryInstr(fltstr, left, right)
 	}
 
-	blk.AppendInst(val)
+	blk.Insts = append(blk.Insts, val)
 
 	return val
 }
@@ -44,8 +45,8 @@ type numericalBinaryOperator struct {
 }
 
 type comparisonOperation struct {
-	I ir.IntPred
-	F ir.FloatPred
+	I enum.IPred
+	F enum.FPred
 }
 
 var binaryOperatorTypeMap = map[string]numericalBinaryOperator{
@@ -62,12 +63,12 @@ var binaryOperatorTypeMap = map[string]numericalBinaryOperator{
 }
 
 var booleanComparisonOperatorMap = map[string]comparisonOperation{
-	"==": {ir.IntEQ, ir.FloatOEQ},
-	"!=": {ir.IntNE, ir.FloatONE},
-	">":  {ir.IntSGT, ir.FloatOGT},
-	">=": {ir.IntSGE, ir.FloatOGE},
-	"<":  {ir.IntSLT, ir.FloatOLT},
-	"<=": {ir.IntSLE, ir.FloatOLE},
+	"==": {enum.IPredEQ, enum.FPredOEQ},
+	"!=": {enum.IPredNE, enum.FPredONE},
+	">":  {enum.IPredSGT, enum.FPredOGT},
+	">=": {enum.IPredSGE, enum.FPredOGE},
+	"<":  {enum.IPredSLT, enum.FPredOLT},
+	"<=": {enum.IPredSLE, enum.FPredOLE},
 }
 
 // BinaryNode is a representation of a binary operation
@@ -322,9 +323,10 @@ func (n AddSubNode) Codegen(prog *Program) (value.Value, error) {
 		opname = "f" + opname
 	}
 
-	result = NewGeodeBinaryInstr(opname, left, right)
-
-	prog.Compiler.CurrentBlock().AppendInst(result.(ir.Instruction))
+	inst := NewGeodeBinaryInstr(opname, left, right)
+	result = inst
+	curBlock := prog.Compiler.CurrentBlock()
+	curBlock.Insts = append(curBlock.Insts, inst)
 
 	if resultcast != nil {
 		result, err = createTypeCast(prog, result, resultcast)

--- a/pkg/ast/BlockNode.go
+++ b/pkg/ast/BlockNode.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir/value"
 )
 
 // BlockNode is a block statement. A block statement is just an array of Nodes

--- a/pkg/ast/BooleanNode.go
+++ b/pkg/ast/BooleanNode.go
@@ -2,7 +2,6 @@ package ast
 
 import (
 	"github.com/llir/llvm/ir/constant"
-	"github.com/llir/llvm/ir/types"
 	"github.com/llir/llvm/ir/value"
 )
 
@@ -20,11 +19,11 @@ func (n BooleanNode) NameString() string { return "BooleanNode" }
 
 // Codegen implements Node.Codegen for BooleanNode
 func (n BooleanNode) Codegen(prog *Program) (value.Value, error) {
-	options := map[string]int64{
-		"true":  1,
-		"false": 0,
+	options := map[string]bool{
+		"true":  true,
+		"false": false,
 	}
-	return constant.NewInt(options[n.Value], types.I1), nil
+	return constant.NewBool(options[n.Value]), nil
 }
 
 func (n BooleanNode) String() string {

--- a/pkg/ast/BooleanNode.go
+++ b/pkg/ast/BooleanNode.go
@@ -1,9 +1,9 @@
 package ast
 
 import (
-	"github.com/geode-lang/geode/llvm/ir/constant"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 )
 
 // BooleanNode is an integer literal

--- a/pkg/ast/Callable.go
+++ b/pkg/ast/Callable.go
@@ -1,9 +1,9 @@
 package ast
 
 import (
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 )
 
 // Callable is for the left side of a function call. It has functions for getting the function that it points to, etc...

--- a/pkg/ast/CastNode.go
+++ b/pkg/ast/CastNode.go
@@ -3,8 +3,8 @@ package ast
 import (
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 )
 
 // CastNode is a structure around a typecast expression

--- a/pkg/ast/ClassNode.go
+++ b/pkg/ast/ClassNode.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	gtypes "github.com/geode-lang/geode/pkg/types"
+	"github.com/geode-lang/geode/pkg/gtypes"
 	"github.com/geode-lang/geode/pkg/util/color"
 	"github.com/llir/llvm/ir"
 	"github.com/llir/llvm/ir/constant"
@@ -103,7 +103,7 @@ func (n ClassNode) String() string {
 
 // Declare a class type
 func (n ClassNode) Declare(prog *Program) (value.Value, error) {
-	structDefn := gtypes.NewStruct(nil)
+	structDefn := gtypes.NewStruct()
 
 	name := fmt.Sprintf("class.%s:%s", prog.Scope.PackageName, n.Name)
 	structDefn.SetName(name)

--- a/pkg/ast/ClassNode.go
+++ b/pkg/ast/ClassNode.go
@@ -226,8 +226,10 @@ func GetStructFieldAlloc(prog *Program, alloc *ir.InstAlloca, field string) valu
 
 	zero := constant.NewInt(types.I32, 0)
 	fieldOffset := constant.NewInt(types.I32, int64(index))
-	gen := prog.Compiler.CurrentBlock().NewGetElementPtr(base, zero, fieldOffset)
-	return gen
+	curBlock := prog.Compiler.CurrentBlock()
+	inst := gep(base, zero, fieldOffset)
+	curBlock.Insts = append(curBlock.Insts, inst)
+	return inst
 }
 
 // GenStructFieldAssignment takes some allocation and assigns the value to a field given some name

--- a/pkg/ast/ClassNode.go
+++ b/pkg/ast/ClassNode.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/constant"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 	"github.com/geode-lang/geode/pkg/util/color"
 )
 

--- a/pkg/ast/ClassNode.go
+++ b/pkg/ast/ClassNode.go
@@ -61,7 +61,7 @@ func (n ClassNode) VerifyCorrectness(prog *Program) error {
 			continue
 		}
 
-		if types.IsStruct(ty) {
+		if gtypes.IsStruct(ty) {
 			// If the type is a direct reference back to the base class, it is invalid. It must be a pointer type
 			if types.Equal(base, ty) {
 				return fmt.Errorf("class '%s' has a circular reference in it's fields. Field '%s' should be a pointer to a '%s' instead", n.Name, f.Name, n.Name)
@@ -69,7 +69,7 @@ func (n ClassNode) VerifyCorrectness(prog *Program) error {
 
 			// Now we need to check if the struct has a non-pointer reference back to this class.
 			// that has the same effect.
-			structT := ty.(*types.StructType)
+			structT := ty.(*gtypes.StructType)
 
 			if contains, _, _ := structContainsTypeAnywhere(structT, base, structT); contains {
 				buff := &bytes.Buffer{}
@@ -82,13 +82,13 @@ func (n ClassNode) VerifyCorrectness(prog *Program) error {
 	return nil
 }
 
-func structContainsTypeAnywhere(s *types.StructType, t types.Type, path ...*types.StructType) (bool, int, []*types.StructType) {
+func structContainsTypeAnywhere(s *gtypes.StructType, t types.Type, path ...*gtypes.StructType) (bool, int, []*gtypes.StructType) {
 	for i, field := range s.Fields {
 		if types.Equal(field, t) {
 			return true, i, path
 		}
-		if types.IsStruct(field) {
-			structType := field.(*types.StructType)
+		if gtypes.IsStruct(field) {
+			structType := field.(*gtypes.StructType)
 			if contains, index, p := structContainsTypeAnywhere(structType, t, append(path, structType)...); contains {
 				return true, index, p
 			}
@@ -192,7 +192,7 @@ func GenerateClassConstruction(name string, typ types.Type, s *Scope, c *Compile
 
 // NewClassInstance takes the class to generate as well as the fields
 // mapped to their value
-func NewClassInstance(prog *Program, stct *types.StructType, fields map[string]value.Value) value.Value {
+func NewClassInstance(prog *Program, stct *gtypes.StructType, fields map[string]value.Value) value.Value {
 
 	alloc := prog.Compiler.CurrentBlock().NewAlloca(stct)
 

--- a/pkg/ast/ClassNode.go
+++ b/pkg/ast/ClassNode.go
@@ -43,7 +43,7 @@ func (n ClassNode) VerifyCorrectness(prog *Program) error {
 		return err
 	}
 
-	base, ok := found.(*types.StructType)
+	base, ok := found.(*gtypes.StructType)
 	if !ok {
 		return fmt.Errorf("unable to cast found type %T to a struct for class %q", found, n.Name)
 	}

--- a/pkg/ast/Compiler.go
+++ b/pkg/ast/Compiler.go
@@ -3,8 +3,8 @@ package ast
 import (
 	"sync"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/types"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/types"
 )
 
 // Compiler contains all information to

--- a/pkg/ast/Compiler.go
+++ b/pkg/ast/Compiler.go
@@ -75,7 +75,8 @@ func (c *Compiler) FunctionDefined(fn *ir.Function) bool {
 
 // NewComment appends a comment string to the current block
 func (c *Compiler) NewComment(comment string) {
-	c.CurrentBlock().AppendInst(NewLLVMComment(comment))
+	curBlock := c.CurrentBlock()
+	curBlock.Insts = append(curBlock.Insts, NewLLVMComment(comment))
 
 }
 

--- a/pkg/ast/DotReference.go
+++ b/pkg/ast/DotReference.go
@@ -108,9 +108,10 @@ func (n DotReference) Alloca(prog *Program) value.Value {
 
 	zero := constant.NewInt(types.I32, 0)
 	fieldOffset := constant.NewInt(types.I32, int64(index))
-	gen := prog.Compiler.CurrentBlock().NewGetElementPtr(base, zero, fieldOffset)
-
-	return gen
+	curBlock := prog.Compiler.CurrentBlock()
+	inst := gep(base, zero, fieldOffset)
+	curBlock.Insts = append(curBlock.Insts, inst)
+	return inst
 }
 
 // NameString implements Node.NameString

--- a/pkg/ast/DotReference.go
+++ b/pkg/ast/DotReference.go
@@ -3,10 +3,10 @@ package ast
 import (
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/constant"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 )
 
 // DotReference -

--- a/pkg/ast/DotReference.go
+++ b/pkg/ast/DotReference.go
@@ -3,7 +3,7 @@ package ast
 import (
 	"fmt"
 
-	gtypes "github.com/geode-lang/geode/pkg/types"
+	"github.com/geode-lang/geode/pkg/gtypes"
 	"github.com/llir/llvm/ir"
 	"github.com/llir/llvm/ir/constant"
 	"github.com/llir/llvm/ir/types"

--- a/pkg/ast/FloatNode.go
+++ b/pkg/ast/FloatNode.go
@@ -21,7 +21,7 @@ func (n FloatNode) NameString() string { return "FloatNode" }
 
 // Codegen implements Node.Codegen for FloatNode
 func (n FloatNode) Codegen(prog *Program) (value.Value, error) {
-	return constant.NewFloat(n.Value, types.Double), nil
+	return constant.NewFloat(types.Double, n.Value), nil
 }
 
 // GenAccess implements Accessable.GenAccess

--- a/pkg/ast/FloatNode.go
+++ b/pkg/ast/FloatNode.go
@@ -3,9 +3,9 @@ package ast
 import (
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir/constant"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 )
 
 // FloatNode is a float literla

--- a/pkg/ast/ForNode.go
+++ b/pkg/ast/ForNode.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/constant"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 )
 
 //

--- a/pkg/ast/FunctionCallNode.go
+++ b/pkg/ast/FunctionCallNode.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 )
 
 // FunctionCallNode is a function call, example: `foo(a, b, c)`. This would be:

--- a/pkg/ast/FunctionCallNode.go
+++ b/pkg/ast/FunctionCallNode.go
@@ -92,10 +92,8 @@ func (n FunctionCallNode) Codegen(prog *Program) (value.Value, error) {
 	}
 
 	// Attempt to typecast all the args into the correct type
-	for i, exp := range callee.Sig.Params {
-		t := exp.Type()
-
-		args[i], _ = createTypeCast(prog, args[i], t)
+	for i, paramType := range callee.Sig.Params {
+		args[i], _ = createTypeCast(prog, args[i], paramType)
 	}
 
 	// Varargs require type conversion to a standardized type
@@ -106,7 +104,7 @@ func (n FunctionCallNode) Codegen(prog *Program) (value.Value, error) {
 
 	for i, arg := range args {
 
-		if callee.Sig.Variadic && i >= len(callee.Params()) {
+		if callee.Sig.Variadic && i >= len(callee.Params) {
 			if types.IsInt(arg.Type()) {
 				if !types.Equal(arg.Type(), types.I32) {
 					c, err := createTypeCast(prog, arg, types.I32)

--- a/pkg/ast/FunctionDiscovery.go
+++ b/pkg/ast/FunctionDiscovery.go
@@ -3,8 +3,8 @@ package ast
 import (
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/types"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/types"
 )
 
 // =========================== FunctionDiscoveryWorker ===========================

--- a/pkg/ast/FunctionNode.go
+++ b/pkg/ast/FunctionNode.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/geode-lang/geode/pkg/arg"
 	"github.com/llir/llvm/ir"
 	"github.com/llir/llvm/ir/types"
 	"github.com/llir/llvm/ir/value"
-	"github.com/geode-lang/geode/pkg/arg"
 )
 
 // FuncDeclKeywordType lets the compiler keep track of
@@ -68,8 +68,8 @@ type FunctionNode struct {
 func (n FunctionNode) NameString() string { return "FunctionNode" }
 
 // Arguments returns some FunctionNode's arguments
-func (n FunctionNode) Arguments(prog *Program) ([]*types.Param, []types.Type, error) {
-	funcArgs := make([]*types.Param, 0)
+func (n FunctionNode) Arguments(prog *Program) ([]*ir.Param, []types.Type, error) {
+	funcArgs := make([]*ir.Param, 0)
 	argTypes := make([]types.Type, 0)
 	for _, arg := range n.Args {
 		found, _ := prog.FindType(arg.Type.Name)
@@ -120,7 +120,7 @@ func (n FunctionNode) Declare(prog *Program) (*ir.Function, error) {
 		return nil, err
 	}
 
-	function := prog.Compiler.Module.NewFunction(namestring, ty, funcArgs...)
+	function := prog.Compiler.Module.NewFunc(namestring, ty, funcArgs...)
 
 	prog.Compiler.PushFunc(function)
 	defer prog.Compiler.PopFunc()
@@ -202,23 +202,22 @@ func (n FunctionNode) Codegen(prog *Program) (value.Value, error) {
 	// If the function is external (has ... at the end) we don't build a block
 	if !n.External {
 		// Create the entrypoint to the function
-		entryBlock := ir.NewBlock(n.Name.String() + "_entry")
-
-		prog.Compiler.CurrentFunc().AppendBlock(entryBlock)
+		curFunc := prog.Compiler.CurrentFunc()
+		entryBlock := curFunc.NewBlock(n.Name.String() + "_entry")
 		prog.Compiler.PushBlock(entryBlock)
 
 		// Construct the prelude of this function
 		// The prelude contains information about
 		// initializing the runtime.
 		createInitializationPrelude(prog, n)
-		if len(function.Params()) > 0 {
+		if len(function.Params) > 0 {
 			// prog.Compiler.CurrentBlock().AppendInst(NewLLVMComment(n.Name.String() + " arguments:"))
 		}
-		for _, arg := range function.Params() {
+		for _, arg := range function.Params {
 			alloc := prog.Compiler.CurrentBlock().NewAlloca(arg.Type())
 			prog.Compiler.CurrentBlock().NewStore(arg, alloc)
 			// Set the scope item
-			scItem := NewVariableScopeItem(arg.Name, alloc, PrivateVisibility)
+			scItem := NewVariableScopeItem(arg.Name(), alloc, PrivateVisibility)
 			prog.Scope.Add(scItem)
 		}
 		// Gen the body of the function
@@ -268,14 +267,14 @@ func createInitializationPrelude(prog *Program, n FunctionNode) {
 	if *arg.DisableRuntime {
 		return
 	}
-	if prog.Compiler.CurrentFunc().Name == "main" {
+	if prog.Compiler.CurrentFunc().Name() == "main" {
 
 		prog.NewRuntimeFunctionCall("__init_runtime")
 
 		prog.Compiler.NewComment("User Code:")
 	}
 
-	if prog.Compiler.CurrentFunc().Name == "__init_runtime" {
+	if prog.Compiler.CurrentFunc().Name() == "__init_runtime" {
 		prog.Compiler.NewComment("Runtime Prelude:")
 
 		if len(prog.Initializations) > 0 {

--- a/pkg/ast/FunctionNode.go
+++ b/pkg/ast/FunctionNode.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 	"github.com/geode-lang/geode/pkg/arg"
 )
 

--- a/pkg/ast/GeodeBinaryOp.go
+++ b/pkg/ast/GeodeBinaryOp.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/metadata"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/metadata"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 )
 
 // GeodeBinaryInstr implements ir.Instruction

--- a/pkg/ast/GeodeBinaryOp.go
+++ b/pkg/ast/GeodeBinaryOp.go
@@ -2,114 +2,60 @@ package ast
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/llir/llvm/ir"
-	"github.com/llir/llvm/ir/metadata"
-	"github.com/llir/llvm/ir/types"
 	"github.com/llir/llvm/ir/value"
 )
 
-// GeodeBinaryInstr implements ir.Instruction
-// This will be easier than doing individual work
-// per operation
-type GeodeBinaryInstr struct {
-	// Parent basic block.
-	Parent *ir.BasicBlock
-	// Name of the local variable associated with the instruction.
-	Name string
-	// Operator string.
-	Operator string
-	// Operands.
-	X, Y value.Value
-	// Map from metadata identifier (e.g. !dbg) to metadata associated with the
-	// instruction.
-	Metadata map[string]*metadata.Metadata
+// BinaryInstruction is a Geode binary instruction.
+type BinaryInstruction interface {
+	ir.Instruction
+	value.Named
 }
 
-// NewGeodeBinaryInstr returns a new geode binary instruction
-func NewGeodeBinaryInstr(op string, x, y value.Value) *GeodeBinaryInstr {
-	return &GeodeBinaryInstr{
-		X:        x,
-		Y:        y,
-		Operator: op,
-		Metadata: make(map[string]*metadata.Metadata),
+// NewGeodeBinaryInstr returns a new binary instruction based on the given
+// operation.
+func NewGeodeBinaryInstr(op string, x, y value.Value) BinaryInstruction {
+	switch op {
+	// Binary instruction.
+	case "add":
+		return ir.NewAdd(x, y)
+	case "fadd":
+		return ir.NewFAdd(x, y)
+	case "sub":
+		return ir.NewSub(x, y)
+	case "fsub":
+		return ir.NewFSub(x, y)
+	case "mul":
+		return ir.NewMul(x, y)
+	case "fmul":
+		return ir.NewFMul(x, y)
+	case "udiv":
+		return ir.NewUDiv(x, y)
+	case "sdiv":
+		return ir.NewSDiv(x, y)
+	case "fdiv":
+		return ir.NewFDiv(x, y)
+	case "urem":
+		return ir.NewURem(x, y)
+	case "srem":
+		return ir.NewSRem(x, y)
+	case "frem":
+		return ir.NewFRem(x, y)
+	// Bitwise instructions.
+	case "shl":
+		return ir.NewShl(x, y)
+	case "lshr":
+		return ir.NewLShr(x, y)
+	case "ashr":
+		return ir.NewAShr(x, y)
+	case "and":
+		return ir.NewAnd(x, y)
+	case "or":
+		return ir.NewOr(x, y)
+	case "xor":
+		return ir.NewXor(x, y)
+	default:
+		panic(fmt.Errorf("support for binary instruction op %q not yet implemented", op))
 	}
-}
-
-func escapeIdent(s string) string {
-	tail := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz$-._0123456789"
-	// Check if a replacement is required.
-	extra := 0
-	for i := 0; i < len(s); i++ {
-		if strings.IndexByte(tail, s[i]) == -1 {
-			// Two extra bytes are required for each invalid byte; e.g.
-			//    "#" -> `\23`
-			//    "世" -> `\E4\B8\96`
-			extra += 2
-		}
-	}
-	if extra == 0 {
-		return s
-	}
-
-	// Replace invalid characters.
-	const hextable = "0123456789ABCDEF"
-	buf := make([]byte, len(s)+extra)
-	j := 0
-	for i := 0; i < len(s); i++ {
-		b := s[i]
-		if strings.IndexByte(tail, b) != -1 {
-			buf[j] = b
-			j++
-			continue
-		}
-		buf[j] = '\\'
-		buf[j+1] = hextable[b>>4]
-		buf[j+2] = hextable[b&0x0F]
-		j += 3
-	}
-	// Add surrounding quotes.
-	return `"` + string(buf) + `"`
-}
-
-// Type returns the type of the instruction.
-func (inst *GeodeBinaryInstr) Type() types.Type {
-	return inst.X.Type()
-}
-
-// Ident returns the identifier associated with the instruction.
-func (inst *GeodeBinaryInstr) Ident() string {
-	return "%" + escapeIdent(inst.Name)
-}
-
-// GetName returns the name of the local variable associated with the
-// instruction.
-func (inst *GeodeBinaryInstr) GetName() string {
-	return inst.Name
-}
-
-// SetName sets the name of the local variable associated with the instruction.
-func (inst *GeodeBinaryInstr) SetName(name string) {
-	inst.Name = name
-}
-
-// String returns the LLVM syntax representation of the instruction.
-func (inst *GeodeBinaryInstr) String() string {
-	return fmt.Sprintf("%s = %s %s %s, %s",
-		inst.Ident(),
-		inst.Operator,
-		inst.Type(),
-		inst.X.Ident(),
-		inst.Y.Ident())
-}
-
-// GetParent returns the parent basic block of the instruction.
-func (inst *GeodeBinaryInstr) GetParent() *ir.BasicBlock {
-	return inst.Parent
-}
-
-// SetParent sets the parent basic block of the instruction.
-func (inst *GeodeBinaryInstr) SetParent(parent *ir.BasicBlock) {
-	inst.Parent = parent
 }

--- a/pkg/ast/GlobalVariableDefn.go
+++ b/pkg/ast/GlobalVariableDefn.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/constant"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/value"
 )
 
 // GlobalVariableDeclNode -

--- a/pkg/ast/GlobalVariableDefn.go
+++ b/pkg/ast/GlobalVariableDefn.go
@@ -46,7 +46,7 @@ func (n GlobalVariableDeclNode) Declare(prog *Program) (value.Value, error) {
 	decl := prog.Module.NewGlobalDef(name, init)
 
 	if !n.External {
-		decl.Name = MangleVariableName(name)
+		decl.SetName(MangleVariableName(name))
 	}
 
 	n.GlobalDecl = decl

--- a/pkg/ast/IdentNode.go
+++ b/pkg/ast/IdentNode.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/geode-lang/geode/pkg/arg"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/metadata"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/metadata"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 	"github.com/geode-lang/geode/pkg/util/color"
 	"github.com/geode-lang/geode/pkg/util/log"
 )

--- a/pkg/ast/IntNode.go
+++ b/pkg/ast/IntNode.go
@@ -23,7 +23,7 @@ func (n IntNode) NameString() string { return "IntNode" }
 // Codegen implements Node.Codegen for IntNode
 func (n IntNode) Codegen(prog *Program) (value.Value, error) {
 	// return llvm.ConstInt(llvm.Int64Type(), , true)
-	return constant.NewInt(n.Value, types.I64), nil
+	return constant.NewInt(types.I64, n.Value), nil
 }
 
 func (n IntNode) String() string {

--- a/pkg/ast/IntNode.go
+++ b/pkg/ast/IntNode.go
@@ -3,9 +3,9 @@ package ast
 import (
 	"strconv"
 
-	"github.com/geode-lang/geode/llvm/ir/constant"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 )
 
 // IntNode is an integer literal

--- a/pkg/ast/LLVMComment.go
+++ b/pkg/ast/LLVMComment.go
@@ -23,6 +23,7 @@ type LLVMComment struct {
 func NewLLVMComment(format string, args ...interface{}) *LLVMComment {
 	zero := constant.NewInt(types.I64, 0)
 	nop := ir.NewAdd(zero, zero)
+	nop.SetName("nop")
 	return &LLVMComment{
 		data:    fmt.Sprintf(format, args...),
 		InstAdd: nop,

--- a/pkg/ast/LLVMComment.go
+++ b/pkg/ast/LLVMComment.go
@@ -2,66 +2,36 @@ package ast
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/llir/llvm/ir"
-	"github.com/llir/llvm/ir/metadata"
+	"github.com/llir/llvm/ir/constant"
 	"github.com/llir/llvm/ir/types"
 )
 
-// LLVMComment implements ir.Instruction
-// This will be easier than doing individual work
-// per operation
+// LLVMComment is a Geode pseud-comment instruction. It implements the
+// ir.Instruction interface by embedding a NOP add instruction.
 type LLVMComment struct {
-	// Parent basic block.
-	Parent *ir.BasicBlock
-
+	// Comment; may contain multiple lines.
 	data string
 
-	// Map from metadata identifier (e.g. !dbg) to metadata associated with the
-	// instruction.
-	Metadata map[string]*metadata.Metadata
+	// LLVMComment implements ir.Instruction by embedding a NOP add instruction.
+	*ir.InstAdd
 }
 
-// NewLLVMComment returns a new geode binary instruction
+// NewLLVMComment returns a new Geode comment pseudo-instruction.
 func NewLLVMComment(format string, args ...interface{}) *LLVMComment {
+	zero := constant.NewInt(types.I64, 0)
+	nop := ir.NewAdd(zero, zero)
 	return &LLVMComment{
-		data:     fmt.Sprintf(format, args...),
-		Metadata: make(map[string]*metadata.Metadata),
+		data:    fmt.Sprintf(format, args...),
+		InstAdd: nop,
 	}
 }
 
-// Type returns the type of the instruction.
-func (inst *LLVMComment) Type() types.Type {
-	return types.Void
-}
-
-// Ident returns the identifier associated with the instruction.
-func (inst *LLVMComment) Ident() string {
-	return "COMMENT"
-}
-
-// GetName returns the name of the local variable associated with the
-// instruction.
-func (inst *LLVMComment) GetName() string {
-	return "COMMENT"
-}
-
-// SetName sets the name of the local variable associated with the instruction.
-func (inst *LLVMComment) SetName(name string) {
-
-}
-
-// String returns the LLVM syntax representation of the instruction.
-func (inst *LLVMComment) String() string {
-	return fmt.Sprintf("; %s", inst.data)
-}
-
-// GetParent returns the parent basic block of the instruction.
-func (inst *LLVMComment) GetParent() *ir.BasicBlock {
-	return inst.Parent
-}
-
-// SetParent sets the parent basic block of the instruction.
-func (inst *LLVMComment) SetParent(parent *ir.BasicBlock) {
-	inst.Parent = parent
+// Def returns the LLVM syntax representation of the instruction.
+func (inst *LLVMComment) Def() string {
+	// Handle multi-line comments.
+	data := strings.Replace(inst.data, "\n", "; ", -1)
+	return fmt.Sprintf("; %s", data)
 }

--- a/pkg/ast/LLVMComment.go
+++ b/pkg/ast/LLVMComment.go
@@ -3,9 +3,9 @@ package ast
 import (
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/metadata"
-	"github.com/geode-lang/geode/llvm/ir/types"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/metadata"
+	"github.com/llir/llvm/ir/types"
 )
 
 // LLVMComment implements ir.Instruction

--- a/pkg/ast/LLVMIdent.go
+++ b/pkg/ast/LLVMIdent.go
@@ -3,9 +3,9 @@ package ast
 import (
 	"strings"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/metadata"
-	"github.com/geode-lang/geode/llvm/ir/types"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/metadata"
+	"github.com/llir/llvm/ir/types"
 )
 
 // LLVMIdent implements ir.Instruction

--- a/pkg/ast/LLVMRaw.go
+++ b/pkg/ast/LLVMRaw.go
@@ -1,9 +1,9 @@
 package ast
 
 import (
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/metadata"
-	"github.com/geode-lang/geode/llvm/ir/types"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/metadata"
+	"github.com/llir/llvm/ir/types"
 )
 
 // LLVMRaw implements ir.Instruction

--- a/pkg/ast/Mangle.go
+++ b/pkg/ast/Mangle.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/geode-lang/geode/llvm/ir/types"
+	"github.com/llir/llvm/ir/types"
 )
 
 //go:generate stringer -type=ManglePartType

--- a/pkg/ast/NilNode.go
+++ b/pkg/ast/NilNode.go
@@ -3,9 +3,9 @@ package ast
 import (
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir/constant"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 )
 
 // NilNode -

--- a/pkg/ast/Nodes.go
+++ b/pkg/ast/Nodes.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/geode-lang/geode/pkg/gtypes"
 	"github.com/geode-lang/geode/pkg/lexer"
-	gtypes "github.com/geode-lang/geode/pkg/types"
 	"github.com/llir/llvm/ir/types"
 	"github.com/llir/llvm/ir/value"
 )

--- a/pkg/ast/Nodes.go
+++ b/pkg/ast/Nodes.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 	"github.com/geode-lang/geode/pkg/lexer"
 )
 

--- a/pkg/ast/Nodes.go
+++ b/pkg/ast/Nodes.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/geode-lang/geode/pkg/lexer"
+	gtypes "github.com/geode-lang/geode/pkg/types"
 	"github.com/llir/llvm/ir/types"
 	"github.com/llir/llvm/ir/value"
-	"github.com/geode-lang/geode/pkg/lexer"
 )
 
 // NodeType -
@@ -305,7 +306,7 @@ func (n TypeNode) GetType(prog *Program) (types.Type, error) {
 			case ModifierPointer:
 				ty = types.NewPointer(ty)
 			case ModifierSlice:
-				ty = types.NewSlice(ty)
+				ty = gtypes.NewSlice(ty)
 			case ModifierUnknown:
 				//
 			default:

--- a/pkg/ast/Program.go
+++ b/pkg/ast/Program.go
@@ -11,14 +11,14 @@ import (
 
 	"path/filepath"
 
-	"github.com/llir/llvm/ir"
-	"github.com/llir/llvm/ir/metadata"
-	"github.com/llir/llvm/ir/types"
-	"github.com/llir/llvm/ir/value"
 	"github.com/geode-lang/geode/pkg/arg"
 	"github.com/geode-lang/geode/pkg/lexer"
 	"github.com/geode-lang/geode/pkg/util"
 	"github.com/geode-lang/geode/pkg/util/log"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/metadata"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 )
 
 // Program is a wrapper for information used
@@ -81,9 +81,9 @@ func (p *Program) ScopeDown(tok lexer.Token) {
 	p.Scope = p.Scope.SpawnChild()
 
 	if *arg.EnableDebug {
-		md := &metadata.Named{}
+		md := &metadata.NamedDef{}
 		md.Name = fmt.Sprintf("scope_%d", p.Scope.Index)
-		p.Module.NamedMetadata = append(p.Module.NamedMetadata, md)
+		p.Module.NamedMetadataDefs = append(p.Module.NamedMetadataDefs, md)
 		p.Scope.DebugInfo = md
 		// md.Metadata
 	}

--- a/pkg/ast/Program.go
+++ b/pkg/ast/Program.go
@@ -11,10 +11,10 @@ import (
 
 	"path/filepath"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/metadata"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/metadata"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 	"github.com/geode-lang/geode/pkg/arg"
 	"github.com/geode-lang/geode/pkg/lexer"
 	"github.com/geode-lang/geode/pkg/util"

--- a/pkg/ast/Program.go
+++ b/pkg/ast/Program.go
@@ -582,7 +582,7 @@ func SearchPaths(base string) []string {
 	sp := make([]string, 0)
 
 	sp = append(sp, base)
-	sp = append(sp, "/usr/local/lib/geodelib")
+	sp = append(sp, util.StdLibDir())
 
 	for base != "/" && base != "." {
 		dir := filepath.Join(base, packagedir)

--- a/pkg/ast/Reference.go
+++ b/pkg/ast/Reference.go
@@ -3,8 +3,8 @@ package ast
 import (
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/value"
 )
 
 // Reference is an interface that other things can implement that

--- a/pkg/ast/Scope.go
+++ b/pkg/ast/Scope.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/geode-lang/geode/pkg/util"
 	"github.com/llir/llvm/ir"
 	"github.com/llir/llvm/ir/metadata"
 	"github.com/llir/llvm/ir/types"
 	"github.com/llir/llvm/ir/value"
-	"github.com/geode-lang/geode/pkg/util"
 )
 
 func init() {
@@ -23,7 +23,7 @@ type Scope struct {
 	Vals        map[string]ScopeItem  `json:"values"`
 	Types       map[string]*ScopeType `json:"types"`
 	PackageName string                `json:"package_name"`
-	DebugInfo   *metadata.Named
+	DebugInfo   *metadata.NamedDef
 }
 
 // Add a value to this specific scope
@@ -365,7 +365,7 @@ func (item FunctionScopeItem) Node() Node {
 // NewFunctionScopeItem constructs a function scope item
 func NewFunctionScopeItem(name string, node FunctionNode, function *ir.Function, vis Visibility) FunctionScopeItem {
 	item := FunctionScopeItem{}
-	item.name = function.Name
+	item.name = function.Name()
 	item.function = function
 	item.vis = vis
 	item.node = node

--- a/pkg/ast/Scope.go
+++ b/pkg/ast/Scope.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/metadata"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/metadata"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 	"github.com/geode-lang/geode/pkg/util"
 )
 

--- a/pkg/ast/StringFormatNode.go
+++ b/pkg/ast/StringFormatNode.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir/value"
 )
 
 // StringFormatNode -

--- a/pkg/ast/StringNode.go
+++ b/pkg/ast/StringNode.go
@@ -3,11 +3,11 @@ package ast
 import (
 	"fmt"
 
+	"github.com/geode-lang/geode/pkg/arg"
 	"github.com/llir/llvm/ir"
 	"github.com/llir/llvm/ir/constant"
 	"github.com/llir/llvm/ir/types"
 	"github.com/llir/llvm/ir/value"
-	"github.com/geode-lang/geode/pkg/arg"
 )
 
 // StringNode -
@@ -34,17 +34,16 @@ func (n StringNode) Codegen(prog *Program) (value.Value, error) {
 		name := fmt.Sprintf(".str.%X", strIndex)
 		strIndex++
 		str = prog.Compiler.Module.NewGlobalDef(name, newCharArray(n.Value))
-		str.IsConst = true
-		str.Immutable()
+		str.Immutable = true
 		prog.StringDefs[n.Value] = str
 	}
 
 	var val value.Value
-	zero := constant.NewInt(0, types.I32)
+	zero := constant.NewInt(types.I32, 0)
 	val = constant.NewGetElementPtr(str, zero, zero)
 
 	if !*arg.DisableStringDataCopy {
-		length := constant.NewInt(int64(len([]byte(n.Value))+1), types.I32)
+		length := constant.NewInt(types.I32, int64(len([]byte(n.Value))+1))
 		v, err := prog.NewRuntimeFunctionCall("raw_copy", val, length)
 		if err != nil {
 			return nil, err

--- a/pkg/ast/StringNode.go
+++ b/pkg/ast/StringNode.go
@@ -3,10 +3,10 @@ package ast
 import (
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/constant"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 	"github.com/geode-lang/geode/pkg/arg"
 )
 

--- a/pkg/ast/SubscriptNode.go
+++ b/pkg/ast/SubscriptNode.go
@@ -3,10 +3,10 @@ package ast
 import (
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/constant"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 )
 
 // SubscriptNode is a recursive subscript operation

--- a/pkg/ast/SubscriptNode.go
+++ b/pkg/ast/SubscriptNode.go
@@ -3,6 +3,7 @@ package ast
 import (
 	"fmt"
 
+	gtypes "github.com/geode-lang/geode/pkg/types"
 	"github.com/llir/llvm/ir"
 	"github.com/llir/llvm/ir/constant"
 	"github.com/llir/llvm/ir/types"
@@ -37,9 +38,9 @@ func (n SubscriptNode) GenElementPtr(prog *Program) (*ir.InstGetElementPtr, erro
 		return nil, err
 	}
 
-	if types.IsSlice(src.Type()) {
+	if gtypes.IsSlice(src.Type()) {
 		fmt.Println(src.Type())
-		zero := constant.NewInt(int64(0), types.I64)
+		zero := constant.NewInt(types.I64, 0)
 		src = prog.Compiler.CurrentBlock().NewGetElementPtr(src, zero)
 	}
 	return prog.Compiler.CurrentBlock().NewGetElementPtr(src, idx), nil

--- a/pkg/ast/SubscriptNode.go
+++ b/pkg/ast/SubscriptNode.go
@@ -3,7 +3,7 @@ package ast
 import (
 	"fmt"
 
-	gtypes "github.com/geode-lang/geode/pkg/types"
+	"github.com/geode-lang/geode/pkg/gtypes"
 	"github.com/llir/llvm/ir"
 	"github.com/llir/llvm/ir/constant"
 	"github.com/llir/llvm/ir/types"

--- a/pkg/ast/SubscriptNode.go
+++ b/pkg/ast/SubscriptNode.go
@@ -41,9 +41,15 @@ func (n SubscriptNode) GenElementPtr(prog *Program) (*ir.InstGetElementPtr, erro
 	if gtypes.IsSlice(src.Type()) {
 		fmt.Println(src.Type())
 		zero := constant.NewInt(types.I64, 0)
-		src = prog.Compiler.CurrentBlock().NewGetElementPtr(src, zero)
+		curBlock := prog.Compiler.CurrentBlock()
+		inst := gep(src, zero)
+		src = inst
+		curBlock.Insts = append(curBlock.Insts, inst)
 	}
-	return prog.Compiler.CurrentBlock().NewGetElementPtr(src, idx), nil
+	curBlock := prog.Compiler.CurrentBlock()
+	inst := gep(src, idx)
+	curBlock.Insts = append(curBlock.Insts, inst)
+	return inst, nil
 }
 
 // Codegen implements Node.Codegen for SubscriptNode

--- a/pkg/ast/TypeInfoNode.go
+++ b/pkg/ast/TypeInfoNode.go
@@ -3,6 +3,7 @@ package ast
 import (
 	"fmt"
 
+	"github.com/geode-lang/geode/pkg/gtypes"
 	"github.com/llir/llvm/ir"
 	"github.com/llir/llvm/ir/constant"
 	"github.com/llir/llvm/ir/types"
@@ -41,7 +42,7 @@ func (n TypeInfoNode) Codegen(prog *Program) (value.Value, error) {
 	// allocation was not found, so we make a new global one.
 	typ, _ := n.Type(prog)
 
-	sct := typ.(*types.StructType)
+	sct := typ.(*gtypes.StructType)
 	globl := prog.Module.NewGlobalDecl(fmt.Sprintf("type_info_%s", n.T), sct)
 
 	globl.Init = constant.NewZeroInitializer(sct)

--- a/pkg/ast/TypeInfoNode.go
+++ b/pkg/ast/TypeInfoNode.go
@@ -52,7 +52,7 @@ func (n TypeInfoNode) Codegen(prog *Program) (value.Value, error) {
 	}
 
 	// https://stackoverflow.com/a/30830445
-	elemptr := constant.NewGetElementPtr(constant.NewNull(types.NewPointer(analyzeType)), constant.NewInt(1, types.I32))
+	elemptr := constant.NewGetElementPtr(constant.NewNull(types.NewPointer(analyzeType)), constant.NewInt(types.I32, 1))
 
 	size := prog.Compiler.CurrentBlock().NewPtrToInt(elemptr, types.I64)
 

--- a/pkg/ast/TypeInfoNode.go
+++ b/pkg/ast/TypeInfoNode.go
@@ -3,10 +3,10 @@ package ast
 import (
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/constant"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 )
 
 // TypeInfoDeclaration is what will be used in the program to keep track of globals

--- a/pkg/ast/VariableDefnNode.go
+++ b/pkg/ast/VariableDefnNode.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/geode-lang/geode/pkg/util/log"
 	"github.com/llir/llvm/ir"
 	"github.com/llir/llvm/ir/constant"
 	"github.com/llir/llvm/ir/types"
 	"github.com/llir/llvm/ir/value"
-	"github.com/geode-lang/geode/pkg/util/log"
 )
 
 // VariableDefnNode -
@@ -84,12 +84,12 @@ func (n VariableDefnNode) Codegen(prog *Program) (value.Value, error) {
 		}
 	}
 
-	prog.Compiler.PushType(alloc.Elem)
+	prog.Compiler.PushType(alloc.ElemType)
 	scItem := NewVariableScopeItem(name.String(), alloc, PrivateVisibility)
 	prog.Scope.Add(scItem)
 
 	if !n.NeedsInference && val != nil {
-		val, err = createTypeCast(prog, val, alloc.Elem)
+		val, err = createTypeCast(prog, val, alloc.ElemType)
 		if err != nil {
 			return nil, err
 		}
@@ -97,7 +97,7 @@ func (n VariableDefnNode) Codegen(prog *Program) (value.Value, error) {
 
 	// If the value is nil, we need to pull the default value for a given type.
 	if val == nil {
-		val = constant.NewZeroInitializer(alloc.Elem)
+		val = constant.NewZeroInitializer(alloc.ElemType)
 	}
 
 	block.NewStore(val, alloc)

--- a/pkg/ast/VariableDefnNode.go
+++ b/pkg/ast/VariableDefnNode.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/constant"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 	"github.com/geode-lang/geode/pkg/util/log"
 )
 

--- a/pkg/ast/VariableNode.go
+++ b/pkg/ast/VariableNode.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir/value"
 )
 
 // VariableNode is a generic variable statement representation

--- a/pkg/ast/codegen.go
+++ b/pkg/ast/codegen.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/geode-lang/geode/pkg/arg"
-	gtypes "github.com/geode-lang/geode/pkg/types"
+	"github.com/geode-lang/geode/pkg/gtypes"
 	"github.com/llir/llvm/ir"
 	"github.com/llir/llvm/ir/constant"
 	"github.com/llir/llvm/ir/enum"

--- a/pkg/ast/codegen.go
+++ b/pkg/ast/codegen.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/constant"
-	"github.com/geode-lang/geode/llvm/ir/metadata"
-	"github.com/geode-lang/geode/llvm/ir/types"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/metadata"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
 	"github.com/geode-lang/geode/pkg/arg"
 )
 

--- a/pkg/ast/codegen.go
+++ b/pkg/ast/codegen.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/geode-lang/geode/pkg/arg"
+	gtypes "github.com/geode-lang/geode/pkg/types"
 	"github.com/llir/llvm/ir"
 	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/enum"
 	"github.com/llir/llvm/ir/metadata"
 	"github.com/llir/llvm/ir/types"
 	"github.com/llir/llvm/ir/value"
-	"github.com/geode-lang/geode/pkg/arg"
 )
 
 // A global number to indicate which `name index` we are on. This way,
@@ -46,7 +48,7 @@ func (n IfNode) Codegen(prog *Program) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	zero := constant.NewInt(0, types.I32)
+	zero := constant.NewInt(types.I32, 0)
 	// The name of the blocks is prefixed because
 	namePrefix := fmt.Sprintf("if.%d.", n.Index)
 	parentBlock := prog.Compiler.CurrentBlock()
@@ -54,7 +56,7 @@ func (n IfNode) Codegen(prog *Program) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	predicate = parentBlock.NewICmp(ir.IntNE, zero, c)
+	predicate = parentBlock.NewICmp(enum.IPredNE, zero, c)
 	parentFunc := parentBlock.Parent
 
 	var thenGenBlk *ir.BasicBlock
@@ -91,12 +93,12 @@ func (n IfNode) Codegen(prog *Program) (value.Value, error) {
 	// We need to make sure these blocks have terminators.
 	// in order to do that, we branch to the end block
 
-	thenBlk.BranchIfNoTerminator(endBlk)
-	thenGenBlk.BranchIfNoTerminator(endBlk)
-	elseBlk.BranchIfNoTerminator(endBlk)
+	BranchIfNoTerminator(thenBlk, endBlk)
+	BranchIfNoTerminator(thenGenBlk, endBlk)
+	BranchIfNoTerminator(elseBlk, endBlk)
 
 	if elseGenBlk != nil {
-		elseGenBlk.BranchIfNoTerminator(endBlk)
+		BranchIfNoTerminator(elseGenBlk, endBlk)
 	}
 
 	parentBlock.NewCondBr(predicate, thenBlk, elseBlk)
@@ -106,7 +108,7 @@ func (n IfNode) Codegen(prog *Program) (value.Value, error) {
 
 // Codegen implements Node.Codegen for CharNode
 func (n CharNode) Codegen(prog *Program) (value.Value, error) {
-	return constant.NewInt(int64(n.Value), types.I8), nil
+	return constant.NewInt(types.I8, int64(n.Value)), nil
 }
 
 // GenAccess returns the value from a given CharNode
@@ -141,9 +143,9 @@ func (n UnaryNode) Codegen(prog *Program) (value.Value, error) {
 	if n.Operator == "-" {
 
 		if types.IsFloat(operandValue.Type()) {
-			return prog.Compiler.CurrentBlock().NewFSub(constant.NewFloat(0, types.Double), operandValue), nil
+			return prog.Compiler.CurrentBlock().NewFSub(constant.NewFloat(types.Double, 0), operandValue), nil
 		} else if types.IsInt(operandValue.Type()) {
-			return prog.Compiler.CurrentBlock().NewSub(constant.NewInt(0, types.I64), operandValue), nil
+			return prog.Compiler.CurrentBlock().NewSub(constant.NewInt(types.I64, 0), operandValue), nil
 		}
 		return nil, fmt.Errorf("Unable to make a non integer/float into a negative")
 
@@ -159,7 +161,7 @@ func (n UnaryNode) Codegen(prog *Program) (value.Value, error) {
 
 		opVal, _ := createTypeCast(prog, operandValue, types.I1)
 
-		eq := prog.Compiler.CurrentBlock().NewICmp(ir.IntNE, opVal, constant.False)
+		eq := prog.Compiler.CurrentBlock().NewICmp(enum.IPredNE, opVal, constant.False)
 		inv := prog.Compiler.CurrentBlock().NewXor(eq, constant.True)
 		ext := prog.Compiler.CurrentBlock().NewZExt(inv, types.I32)
 
@@ -200,14 +202,14 @@ func (n WhileNode) Codegen(prog *Program) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	one := constant.NewInt(1, types.I1)
+	one := constant.NewInt(types.I1, 1)
 	prog.Compiler.PopBlock()
-	parentBlock.BranchIfNoTerminator(startblock)
+	BranchIfNoTerminator(parentBlock, startblock)
 	c, err := createTypeCast(prog, predicate, types.I1)
 	if err != nil {
 		return nil, err
 	}
-	predicate = startblock.NewICmp(ir.IntEQ, one, c)
+	predicate = startblock.NewICmp(enum.IPredEQ, one, c)
 
 	var endBlk *ir.BasicBlock
 
@@ -226,8 +228,8 @@ func (n WhileNode) Codegen(prog *Program) (value.Value, error) {
 	endBlk = parentFunc.NewBlock(mangleName(namePrefix + "merge"))
 	prog.Compiler.PushBlock(endBlk)
 
-	bodyBlk.BranchIfNoTerminator(startblock)
-	bodyGenBlk.BranchIfNoTerminator(startblock)
+	BranchIfNoTerminator(bodyBlk, startblock)
+	BranchIfNoTerminator(bodyGenBlk, startblock)
 
 	startblock.NewCondBr(predicate, bodyBlk, endBlk)
 
@@ -237,18 +239,18 @@ func (n WhileNode) Codegen(prog *Program) (value.Value, error) {
 }
 
 func typeSize(t types.Type) int {
-	if types.IsInt(t) {
-		return t.(*types.IntType).Size
-	}
-	if types.IsFloat(t) {
-		return int(t.(*types.FloatType).Kind)
+	switch t := t.(type) {
+	case *types.IntType:
+		return int(t.BitSize)
+	case *types.FloatType:
+		return gtypes.FloatBitSize(t)
 	}
 
 	return -1
 }
 
 func typesAreLooselyEqual(a, b types.Type) bool {
-	return types.IsNumber(a) && types.IsNumber(b)
+	return gtypes.IsNumber(a) && gtypes.IsNumber(b)
 }
 
 // createTypeCast is where most, if not all, type casting happens in the language.
@@ -337,7 +339,7 @@ func (n ReturnNode) Codegen(prog *Program) (value.Value, error) {
 	var retVal value.Value
 	var err error
 
-	if prog.Compiler.CurrentFunc().Sig.Ret != types.Void {
+	if !prog.Compiler.CurrentFunc().Sig.RetType.Equal(types.Void) {
 		if n.Value != nil {
 			retVal, err = n.Value.Codegen(prog)
 			if err != nil {
@@ -345,11 +347,11 @@ func (n ReturnNode) Codegen(prog *Program) (value.Value, error) {
 				return nil, err
 			}
 			given := retVal.Type()
-			expected := prog.Compiler.CurrentFunc().Sig.Ret
+			expected := prog.Compiler.CurrentFunc().Sig.RetType
 			if !types.Equal(given, expected) {
 				if !(types.IsInt(given) && types.IsInt(expected)) {
 					n.SyntaxError()
-					fnName, err := UnmangleFunctionName(prog.Compiler.CurrentFunc().Name)
+					fnName, err := UnmangleFunctionName(prog.Compiler.CurrentFunc().Name())
 					if err != nil {
 
 						return nil, err
@@ -367,7 +369,7 @@ func (n ReturnNode) Codegen(prog *Program) (value.Value, error) {
 
 					return nil, fmt.Errorf("incorrect return value for function %s. expected: %s (%s). given: %s (%s)", fnName, expectedName, expected, givenName, given)
 				}
-				retVal, err = createTypeCast(prog, retVal, prog.Compiler.CurrentFunc().Sig.Ret)
+				retVal, err = createTypeCast(prog, retVal, prog.Compiler.CurrentFunc().Sig.RetType)
 				if err != nil {
 
 					return nil, err
@@ -382,24 +384,19 @@ func (n ReturnNode) Codegen(prog *Program) (value.Value, error) {
 	ret := prog.Compiler.CurrentBlock().NewRet(retVal)
 
 	if *arg.EnableDebug {
-		md := &metadata.Metadata{}
-		md.Add(metadata.NewRaw(n.Token.DILocation(prog.Scope.DebugInfo)))
-		ret.Metadata["dbg"] = md
+		mdNode := n.Token.DILocation(prog.Scope.DebugInfo)
+		md := &metadata.Attachment{
+			Name: "dbg",
+			Node: mdNode,
+		}
+		ret.Metadata = append(ret.Metadata, md)
 	}
 
 	return retVal, nil
 }
 
-func newCharArray(s string) *constant.Array {
-	var bs []constant.Constant
-	for i := 0; i < len(s); i++ {
-		b := constant.NewInt(int64(s[i]), types.I8)
-		bs = append(bs, b)
-	}
-	bs = append(bs, constant.NewInt(0, types.I8))
-	c := constant.NewArray(bs...)
-	c.CharArray = true
-	return c
+func newCharArray(s string) *constant.CharArray {
+	return constant.NewCharArray([]byte(s))
 }
 
 // CreateEntryBlockAlloca - Create an alloca instruction in the entry block of
@@ -416,4 +413,12 @@ func createBlockAlloca(f *ir.Function, elemType types.Type, name string) *ir.Ins
 func codegenError(str string, args ...interface{}) value.Value {
 	fmt.Fprintf(os.Stderr, "Error: %s\n", fmt.Sprintf(str, args...))
 	return nil
+}
+
+// BranchIfNoTerminator checks if the block has a terminator, and if it doesn't,
+// set it to a branch instead.
+func BranchIfNoTerminator(block, target *ir.BasicBlock) {
+	if block.Term == nil {
+		block.NewBr(target)
+	}
 }

--- a/pkg/ast/codegen.go
+++ b/pkg/ast/codegen.go
@@ -395,9 +395,12 @@ func (n ReturnNode) Codegen(prog *Program) (value.Value, error) {
 	return retVal, nil
 }
 
-// newCharArray returns a character array constant based on the given string.
+// newCharArray returns a NULL-terminated character array constant based on the
+// given string.
 func newCharArray(s string) *constant.CharArray {
-	return constant.NewCharArray([]byte(s))
+	// Add NULL-byte.
+	buf := append([]byte(s), 0)
+	return constant.NewCharArray(buf)
 }
 
 // CreateEntryBlockAlloca - Create an alloca instruction in the entry block of

--- a/pkg/ast/parseNumericExpr.go
+++ b/pkg/ast/parseNumericExpr.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/geode-lang/geode/llvm/ir/types"
+	"github.com/llir/llvm/ir/types"
 )
 
 func (p *Parser) parseNumericExpr() Node {

--- a/pkg/cmd/geode/test.go
+++ b/pkg/cmd/geode/test.go
@@ -244,7 +244,7 @@ func RunTests(testDirectory string) int {
 
 	}
 
-	fmt.Printf("->\t%d/%d (%.0f%%) tests ran succesfully\n\n", numSucceses, numTests, float64(numSucceses)/float64(numTests)*100)
+	fmt.Printf("->\t%d/%d (%.0f%%) tests ran successfully\n\n", numSucceses, numTests, float64(numSucceses)/float64(numTests)*100)
 	if numSucceses < numTests {
 		os.Exit(1)
 		return 1

--- a/pkg/gtypes/size.go
+++ b/pkg/gtypes/size.go
@@ -1,4 +1,4 @@
-package types
+package gtypes
 
 import (
 	"fmt"

--- a/pkg/gtypes/slice.go
+++ b/pkg/gtypes/slice.go
@@ -24,8 +24,7 @@ func NewSlice(elem types.Type) *SliceType {
 	}
 }
 
-// IsSlice reports whether the given type is a Geode slice type.
-func IsSlice(t types.Type) bool {
-	_, ok := t.(*SliceType)
-	return ok
+// Underlying returns the underlying LLVM IR type of the Geode slice type.
+func (t *SliceType) Underlying() types.Type {
+	return t.StructType
 }

--- a/pkg/gtypes/slice.go
+++ b/pkg/gtypes/slice.go
@@ -1,4 +1,4 @@
-package types
+package gtypes
 
 import (
 	"github.com/llir/llvm/ir/types"

--- a/pkg/gtypes/struct.go
+++ b/pkg/gtypes/struct.go
@@ -21,6 +21,11 @@ func NewStruct(fields ...types.Type) *StructType {
 	}
 }
 
+// Underlying returns the underlying LLVM IR type of the Geode struct type.
+func (t *StructType) Underlying() types.Type {
+	return t.StructType
+}
+
 // FieldIndex returns the index of some field in the struct, or -1 if not
 // present.
 func (t *StructType) FieldIndex(name string) int {

--- a/pkg/gtypes/struct.go
+++ b/pkg/gtypes/struct.go
@@ -1,4 +1,4 @@
-package types
+package gtypes
 
 import (
 	"github.com/llir/llvm/ir/types"

--- a/pkg/gtypes/types.go
+++ b/pkg/gtypes/types.go
@@ -3,7 +3,28 @@ package gtypes
 
 import "github.com/llir/llvm/ir/types"
 
+// Type is a Geode type.
+type Type interface {
+	types.Type
+	// Underlying returns the underlying LLVM IR type of the Geode type.
+	Underlying() types.Type
+}
+
 // IsNumber reports whether the given type is an integer or floating-point type.
 func IsNumber(t types.Type) bool {
 	return types.IsInt(t) || types.IsFloat(t)
+}
+
+// IsSlice reports whether the given type is a Geode slice type.
+func IsSlice(t types.Type) bool {
+	_, ok := t.(*SliceType)
+	return ok
+}
+
+// IsStruct reports whether the given type is a struct type.
+func IsStruct(t types.Type) bool {
+	if u, ok := t.(Type); ok {
+		t = u.Underlying()
+	}
+	return types.IsStruct(t)
 }

--- a/pkg/gtypes/types.go
+++ b/pkg/gtypes/types.go
@@ -1,5 +1,5 @@
-// Package types declares the data types of Geode.
-package types
+// Package gtypes declares the data types of Geode.
+package gtypes
 
 import "github.com/llir/llvm/ir/types"
 

--- a/pkg/lexer/Token.go
+++ b/pkg/lexer/Token.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/geode-lang/geode/llvm/ir/metadata"
-	"github.com/geode-lang/geode/llvm/ir/types"
+	"github.com/llir/llvm/ir/metadata"
+	"github.com/llir/llvm/ir/types"
 	"github.com/geode-lang/geode/pkg/debug"
 	"github.com/geode-lang/geode/pkg/util/color"
 )

--- a/pkg/lexer/Token.go
+++ b/pkg/lexer/Token.go
@@ -114,8 +114,11 @@ func (t *Token) DebugFileInfo() *debug.FileInfo {
 }
 
 // DILocation returns the string DILocation for debugging of this token
-func (t *Token) DILocation(scope *metadata.NamedDef) string {
-	info := t.DebugFileInfo()
-	info.Scope = scope
-	return debug.DILocation(info)
+func (t *Token) DILocation(scope *metadata.NamedDef) *metadata.DILocation {
+	return &metadata.DILocation{
+		// TODO: add t.source.Path?
+		Scope:  scope,
+		Line:   int64(t.Line),
+		Column: int64(t.Column),
+	}
 }

--- a/pkg/lexer/Token.go
+++ b/pkg/lexer/Token.go
@@ -7,10 +7,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/llir/llvm/ir/metadata"
-	"github.com/llir/llvm/ir/types"
 	"github.com/geode-lang/geode/pkg/debug"
 	"github.com/geode-lang/geode/pkg/util/color"
+	"github.com/llir/llvm/ir/metadata"
+	"github.com/llir/llvm/ir/types"
 )
 
 // TokenIsOperator will return if a given token is an operator or not
@@ -114,7 +114,7 @@ func (t *Token) DebugFileInfo() *debug.FileInfo {
 }
 
 // DILocation returns the string DILocation for debugging of this token
-func (t *Token) DILocation(scope *metadata.Named) string {
+func (t *Token) DILocation(scope *metadata.NamedDef) string {
 	info := t.DebugFileInfo()
 	info.Scope = scope
 	return debug.DILocation(info)

--- a/pkg/lexer/Token.go
+++ b/pkg/lexer/Token.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/geode-lang/geode/pkg/debug"
 	"github.com/geode-lang/geode/pkg/util/color"
 	"github.com/llir/llvm/ir/metadata"
 	"github.com/llir/llvm/ir/types"
@@ -102,15 +101,6 @@ func (t Token) InferType() (types.Type, interface{}) {
 	}
 
 	return nil, nil
-}
-
-// DebugFileInfo returns the debug.FileInfo for this token
-func (t *Token) DebugFileInfo() *debug.FileInfo {
-	info := &debug.FileInfo{}
-	info.Column = t.Column
-	info.Line = t.Line
-	info.Path = t.source.Path
-	return info
 }
 
 // DILocation returns the string DILocation for debugging of this token

--- a/pkg/types/size.go
+++ b/pkg/types/size.go
@@ -1,4 +1,3 @@
-// Package types declares the data types of Geode.
 package types
 
 import (
@@ -111,4 +110,24 @@ func SliceByteCount(t *SliceType) int {
 	size := ByteCount(t.ElemType)
 	size += ByteCount(types.I64)
 	return size
+}
+
+// FloatBitSize returns the bit size of the given floating-point type.
+func FloatBitSize(t *types.FloatType) int {
+	switch t.Kind {
+	case types.FloatKindHalf:
+		return 16
+	case types.FloatKindFloat:
+		return 32
+	case types.FloatKindDouble:
+		return 64
+	case types.FloatKindFP128:
+		return 128
+	case types.FloatKindX86FP80:
+		return 80
+	case types.FloatKindPPCFP128:
+		return 128
+	default:
+		panic(fmt.Errorf("support for floating-point kind %q not yet implemented", t.Kind))
+	}
 }

--- a/pkg/types/size.go
+++ b/pkg/types/size.go
@@ -1,0 +1,114 @@
+// Package types declares the data types of Geode.
+package types
+
+import (
+	"fmt"
+
+	"github.com/llir/llvm/ir/types"
+)
+
+// ByteCount returns the byte size of the type.
+func ByteCount(t types.Type) int {
+	switch t := t.(type) {
+	case *types.ArrayType:
+		return ArrayByteCount(t)
+	case *types.StructType:
+		return StructByteCount(t)
+	case *types.VoidType:
+		return VoidByteCount(t)
+	case *types.FuncType:
+		return FuncByteCount(t)
+	case *types.LabelType:
+		return LabelByteCount(t)
+	case *types.MetadataType:
+		return MetadataByteCount(t)
+	case *types.IntType:
+		return IntByteCount(t)
+	case *types.FloatType:
+		return FloatByteCount(t)
+	case *types.PointerType:
+		return PointerByteCount(t)
+	case *types.VectorType:
+		return VectorByteCount(t)
+	case *SliceType:
+		return SliceByteCount(t)
+	default:
+		panic(fmt.Errorf("support for type %T not yet implemented", t))
+	}
+}
+
+// ArrayByteCount returns the byte size of the type.
+func ArrayByteCount(t *types.ArrayType) int {
+	return 8
+}
+
+// StructByteCount returns the byte size of the type.
+func StructByteCount(t *types.StructType) int {
+	var size int
+	for _, ty := range t.Fields {
+		size += ByteCount(ty)
+	}
+	return size
+}
+
+// VoidByteCount returns the byte size of the type.
+func VoidByteCount(t *types.VoidType) int {
+	return 8
+}
+
+// FuncByteCount returns the byte size of the type.
+func FuncByteCount(t *types.FuncType) int {
+	return 8
+}
+
+// LabelByteCount returns the byte size of the type.
+func LabelByteCount(t *types.LabelType) int {
+	return 8
+}
+
+// MetadataByteCount returns the byte size of the type.
+func MetadataByteCount(t *types.MetadataType) int {
+	return 0
+}
+
+// IntByteCount returns the byte size of the type.
+func IntByteCount(t *types.IntType) int {
+	return int(t.BitSize) / 8
+}
+
+// FloatByteCount returns the byte size of the type.
+func FloatByteCount(t *types.FloatType) int {
+	switch t.Kind {
+	case types.FloatKindHalf:
+		return 2
+	case types.FloatKindFloat:
+		return 4
+	case types.FloatKindDouble:
+		return 8
+	case types.FloatKindFP128:
+		return 16
+	case types.FloatKindX86FP80:
+		return 10
+	case types.FloatKindPPCFP128:
+		return 16
+	default:
+		panic(fmt.Errorf("support for floating-point kind %q not yet implemented", t.Kind))
+	}
+}
+
+// PointerByteCount returns the byte size of the type.
+func PointerByteCount(t *types.PointerType) int {
+	return 8
+}
+
+// VectorByteCount returns the byte size of the type.
+func VectorByteCount(t *types.VectorType) int {
+	return ByteCount(t.ElemType) * int(t.Len)
+}
+
+// SliceByteCount returns the byte size of the type.
+func SliceByteCount(t *SliceType) int {
+	size := ByteCount(t.ElemType)
+	size += ByteCount(types.I64)
+	return size
+}

--- a/pkg/types/slice.go
+++ b/pkg/types/slice.go
@@ -14,7 +14,7 @@ type SliceType struct {
 	*types.StructType
 }
 
-// NewSlice returns a new slice type based on the given element type.
+// NewSlice returns a new Geode slice type based on the given element type.
 func NewSlice(elem types.Type) *SliceType {
 	length := types.I64
 	typ := types.NewStruct(types.NewPointer(elem), length)
@@ -22,4 +22,10 @@ func NewSlice(elem types.Type) *SliceType {
 		ElemType:   elem,
 		StructType: typ,
 	}
+}
+
+// IsSlice reports whether the given type is a Geode slice type.
+func IsSlice(t types.Type) bool {
+	_, ok := t.(*SliceType)
+	return ok
 }

--- a/pkg/types/slice.go
+++ b/pkg/types/slice.go
@@ -1,0 +1,25 @@
+package types
+
+import (
+	"github.com/llir/llvm/ir/types"
+)
+
+// SliceType type is a Geode slice type.
+type SliceType struct {
+	// Element type.
+	ElemType types.Type
+
+	// A Geode slice type is implemented as an LLVM struct type.
+	//    { elem*, length }
+	*types.StructType
+}
+
+// NewSlice returns a new slice type based on the given element type.
+func NewSlice(elem types.Type) *SliceType {
+	length := types.I64
+	typ := types.NewStruct(types.NewPointer(elem), length)
+	return &SliceType{
+		ElemType:   elem,
+		StructType: typ,
+	}
+}

--- a/pkg/types/struct.go
+++ b/pkg/types/struct.go
@@ -1,0 +1,33 @@
+package types
+
+import (
+	"github.com/llir/llvm/ir/types"
+)
+
+// StructType type is a Geode struct type.
+type StructType struct {
+	// Field names.
+	Names []string
+
+	// A Geode struct type is implemented as an LLVM struct type.
+	*types.StructType
+}
+
+// NewStruct returns a new Geode struct type based on the given field types. The
+// associated field names may be specified through t.Names.
+func NewStruct(fields ...types.Type) *StructType {
+	return &StructType{
+		StructType: types.NewStruct(fields...),
+	}
+}
+
+// FieldIndex returns the index of some field in the struct, or -1 if not
+// present.
+func (t *StructType) FieldIndex(name string) int {
+	for i, n := range t.Names {
+		if n == name {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,0 +1,9 @@
+// Package types declares the data types of Geode.
+package types
+
+import "github.com/llir/llvm/ir/types"
+
+// IsNumber reports whether the given type is an integer or floating-point type.
+func IsNumber(t types.Type) bool {
+	return types.IsInt(t) || types.IsFloat(t)
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -63,6 +64,12 @@ func StdLibDir() string {
 	libpath := os.Getenv("GEODELIB")
 	if libpath == "" {
 		libpath = "/usr/local/lib/geodelib"
+	} else {
+		absPath, err := filepath.Abs(libpath)
+		if err != nil {
+			panic(fmt.Errorf("unable to locate absolute directory of standard library at %q", libpath))
+		}
+		libpath = absPath
 	}
 	return libpath
 }

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -31,7 +31,7 @@ func (v *VirtualMachine) RunFunctionName(fnName string, args ...Value) (Value, e
 	var function *ir.Function
 
 	for _, fn := range v.Module.Funcs {
-		if fn.Name == fnName {
+		if fn.Name() == fnName {
 			function = fn
 		}
 	}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -3,8 +3,8 @@ package vm
 import (
 	"fmt"
 
-	"github.com/geode-lang/geode/llvm/ir"
-	"github.com/geode-lang/geode/llvm/ir/value"
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/value"
 )
 
 // VirtualMachine is a structure that can run a *ir.Module


### PR DESCRIPTION
This is a quite substantial change to Geode as it attempts to make use of an *unmodified* version of [llir/llvm](https://github.com/llir/llvm). To accomplish this, two Geode specific types are defined in the new `pkg/gtypes` package, a Geode struct type and a Geode slice type:

```go
// SliceType type is a Geode slice type.
type SliceType struct {
	// Element type.
	ElemType types.Type

	// A Geode slice type is implemented as an LLVM struct type.
	//    { elem*, length }
	*types.StructType
}

// StructType type is a Geode struct type.
type StructType struct {
	// Field names.
	Names []string

	// A Geode struct type is implemented as an LLVM struct type.
	*types.StructType
}
```

Whether this is a good fit for Geode is yet to be determined.

The main benefit is that with this approach, Geode would be able to use updates to `llir/llvm` seamlessly, and all Geode specific features are implemented on top of the LLVM IR agnostic llir/llvm library.

With this PR, the latest version of llir/llvm is used (`v0.3.0`). All test cases of Geode are passing:

```
$ geode test
(1)	OKAY after return
(2)	OKAY arithmetic
(3)	OKAY array declaration 1
(4)	OKAY array declaration 2
(5)	OKAY classes 1 (Type Declaration)
(6)	OKAY classes 2 (Assigning and Accessing)
(7)	OKAY fibonacci
(8)	OKAY FizzBuzz
(9)	OKAY For Loops
(10)	OKAY global variables 1
(11)	OKAY global variables 2
(12)	OKAY global variables 3
(13)	OKAY global variables 4
(14)	OKAY Hello world
(15)	OKAY Conditional nesting
(16)	OKAY link
(17)	OKAY Minimal Program
(18)	OKAY Unicode 1: Function Names
(19)	OKAY Unicode 2: Variable Names
(20)	OKAY Unicode 3: String contents
(21)	OKAY unknown types 1
(22)	OKAY unknown types 2
(23)	OKAY while
->	23/23 (100%) tests ran successfully
```

This PR fixes #22 and superseeds PR #23.

**Note:** after this commit has been merged, the `llvm` subdirectory of the Geode repository may be removed, as the upstream llir/llvm repo is used unmodified. Also, a `go.mod` file has been added to track the specific versions of dependencies.