### PR TITLE
update to latest version of llir/llvm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,15 +6,15 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
-	github.com/inspirer/textmapper v0.0.0-20181209132054-5280caf89d64 // indirect
 	github.com/kr/pretty v0.1.0
-	github.com/llir/llvm v0.3.0-pre4.0.20181210021817-cba86447c61e
-	github.com/pkg/errors v0.8.0
+	github.com/llir/llvm v0.3.0-pre6.0.20190109195651-59d9946db6ba
+	github.com/pkg/errors v0.8.1
 	github.com/sergi/go-diff v1.0.0
 	github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0
+	github.com/stretchr/testify v1.3.0 // indirect
 	github.com/tcnksm/go-input v0.0.0-20180404061846-548a7d7a8ee8
-	golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 // indirect
-	golang.org/x/sys v0.0.0-20181208175041-ad97f365e150 // indirect
-	golang.org/x/tools v0.0.0-20181207222222-4c874b978acb // indirect
+	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc // indirect
+	golang.org/x/sys v0.0.0-20190109145017-48ac38b7c8cb // indirect
+	golang.org/x/tools v0.0.0-20190109165630-d30e00c24034 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )

--- a/pkg/ast/BinaryNode.go
+++ b/pkg/ast/BinaryNode.go
@@ -10,7 +10,7 @@ import (
 	"github.com/llir/llvm/ir/value"
 )
 
-func createCmp(blk *ir.BasicBlock, i enum.IPred, f enum.FPred, t types.Type, left, right value.Value) value.Value {
+func createCmp(blk *ir.Block, i enum.IPred, f enum.FPred, t types.Type, left, right value.Value) value.Value {
 
 	var val value.Value
 
@@ -25,7 +25,7 @@ func createCmp(blk *ir.BasicBlock, i enum.IPred, f enum.FPred, t types.Type, lef
 }
 
 // CreateBinaryOp produces a geode binary op (just a wrapper around geode-lang/geode/llvm's binary instructions)
-func CreateBinaryOp(intstr, fltstr string, blk *ir.BasicBlock, t types.Type, left, right value.Value) value.Value {
+func CreateBinaryOp(intstr, fltstr string, blk *ir.Block, t types.Type, left, right value.Value) value.Value {
 
 	var val BinaryInstruction
 	if types.IsInt(t) {

--- a/pkg/ast/Callable.go
+++ b/pkg/ast/Callable.go
@@ -8,5 +8,5 @@ import (
 
 // Callable is for the left side of a function call. It has functions for getting the function that it points to, etc...
 type Callable interface {
-	GetFunc(*Program, []types.Type) (*ir.Function, []value.Value, error)
+	GetFunc(*Program, []types.Type) (*ir.Func, []value.Value, error)
 }

--- a/pkg/ast/Compiler.go
+++ b/pkg/ast/Compiler.go
@@ -14,17 +14,17 @@ type Compiler struct {
 	// A reference to the scope in the package for easier access
 	Package *Package
 	Module  *ir.Module
-	blocks  []*ir.BasicBlock
-	// FN            *ir.Function // current funciton being compiled
+	blocks  []*ir.Block
+	// FN            *ir.Func // current funciton being compiled
 	typeStack     []types.Type
 	typestacklock sync.RWMutex
 
-	fnStack     []*ir.Function
+	fnStack     []*ir.Func
 	fnstacklock sync.RWMutex
 }
 
 // CurrentBlock -
-func (c *Compiler) CurrentBlock() *ir.BasicBlock {
+func (c *Compiler) CurrentBlock() *ir.Block {
 	l := len(c.blocks)
 	if l == 0 {
 		return nil
@@ -45,13 +45,13 @@ func (c *Compiler) Copy() *Compiler {
 }
 
 // PushBlock -
-func (c *Compiler) PushBlock(blk *ir.BasicBlock) {
+func (c *Compiler) PushBlock(blk *ir.Block) {
 
 	c.blocks = append(c.blocks, blk)
 }
 
 // PopBlock -
-func (c *Compiler) PopBlock() *ir.BasicBlock {
+func (c *Compiler) PopBlock() *ir.Block {
 	l := len(c.blocks)
 	if l == 0 {
 		return nil
@@ -64,7 +64,7 @@ func (c *Compiler) PopBlock() *ir.BasicBlock {
 
 // FunctionDefined returns whether or not a function
 // with a name has been defined in the module's scope
-func (c *Compiler) FunctionDefined(fn *ir.Function) bool {
+func (c *Compiler) FunctionDefined(fn *ir.Func) bool {
 	for _, defined := range c.Module.Funcs {
 		if defined == fn {
 			return true
@@ -80,7 +80,7 @@ func (c *Compiler) NewComment(comment string) {
 
 }
 
-func (c *Compiler) genInBlock(blk *ir.BasicBlock, fn func() error) error {
+func (c *Compiler) genInBlock(blk *ir.Block, fn func() error) error {
 	c.PushBlock(blk)
 	err := fn()
 	c.PopBlock()
@@ -115,13 +115,13 @@ func NewCompiler(prog *Program) *Compiler {
 	// Initialize the module for this compiler.
 	comp.Module = prog.Module
 
-	comp.blocks = make([]*ir.BasicBlock, 0)
+	comp.blocks = make([]*ir.Block, 0)
 	comp.typeStack = make([]types.Type, 0)
 	return comp
 }
 
 // PushFunc appends a Func to the compiler's Func stack
-func (c *Compiler) PushFunc(fn *ir.Function) {
+func (c *Compiler) PushFunc(fn *ir.Func) {
 	// fmt.Println("pushing", fn.Name)
 	c.fnstacklock.Lock()
 	c.fnStack = append(c.fnStack, fn)
@@ -129,7 +129,7 @@ func (c *Compiler) PushFunc(fn *ir.Function) {
 }
 
 // PopFunc removes an Item from the top of the stack of functions
-func (c *Compiler) PopFunc() (fn *ir.Function) {
+func (c *Compiler) PopFunc() (fn *ir.Func) {
 	c.fnstacklock.Lock()
 	if len(c.fnStack) >= 1 {
 		fn = c.fnStack[len(c.fnStack)-1]
@@ -141,6 +141,6 @@ func (c *Compiler) PopFunc() (fn *ir.Function) {
 }
 
 // CurrentFunc returns the top of the function stack
-func (c *Compiler) CurrentFunc() *ir.Function {
+func (c *Compiler) CurrentFunc() *ir.Func {
 	return c.fnStack[len(c.fnStack)-1]
 }

--- a/pkg/ast/DotReference.go
+++ b/pkg/ast/DotReference.go
@@ -50,7 +50,7 @@ func (n DotReference) BaseAddr(prog *Program) value.Value {
 }
 
 // GetFunc implements Callable.GetFunc
-func (n DotReference) GetFunc(prog *Program, argTypes []types.Type) (*ir.Function, []value.Value, error) {
+func (n DotReference) GetFunc(prog *Program, argTypes []types.Type) (*ir.Func, []value.Value, error) {
 
 	class := n.BaseType(prog)
 
@@ -123,7 +123,7 @@ func (n DotReference) Codegen(prog *Program) (value.Value, error) {
 }
 
 // Load returns a load instruction on a named reference with the given name
-func (n DotReference) Load(block *ir.BasicBlock, prog *Program) *ir.InstLoad {
+func (n DotReference) Load(block *ir.Block, prog *Program) *ir.InstLoad {
 	target := n.Alloca(prog).(*ir.InstGetElementPtr)
 	t, _ := n.Type(prog)
 	target.Typ = types.NewPointer(t)

--- a/pkg/ast/ForNode.go
+++ b/pkg/ast/ForNode.go
@@ -41,10 +41,10 @@ func (n ForNode) Codegen(prog *Program) (value.Value, error) {
 	prog.ScopeDown(n.Token)
 	var err error
 	var predicate value.Value
-	var condBlk *ir.BasicBlock
-	var bodyBlk *ir.BasicBlock
-	var bodyGenBlk *ir.BasicBlock
-	var endBlk *ir.BasicBlock
+	var condBlk *ir.Block
+	var bodyBlk *ir.Block
+	var bodyGenBlk *ir.Block
+	var endBlk *ir.Block
 	parentFunc := parentBlock.Parent
 
 	condBlk = parentFunc.NewBlock(namePrefix + "cond")
@@ -79,7 +79,7 @@ func (n ForNode) Codegen(prog *Program) (value.Value, error) {
 			return err
 		}
 		prog.Scope = scp
-		bodyGenBlk = gen.(*ir.BasicBlock)
+		bodyGenBlk = gen.(*ir.Block)
 		if err != nil {
 			return err
 		}

--- a/pkg/ast/FunctionCallNode.go
+++ b/pkg/ast/FunctionCallNode.go
@@ -148,7 +148,7 @@ func (n FunctionCallNode) Alloca(prog *Program) value.Value {
 }
 
 // Load implements Reference.Load
-func (n FunctionCallNode) Load(blk *ir.BasicBlock, prog *Program) *ir.InstLoad {
+func (n FunctionCallNode) Load(blk *ir.Block, prog *Program) *ir.InstLoad {
 	ld, _ := n.Codegen(prog)
 	return ld.(*ir.InstLoad)
 }

--- a/pkg/ast/FunctionDiscovery.go
+++ b/pkg/ast/FunctionDiscovery.go
@@ -75,5 +75,5 @@ type FunctionDiscoveryResult struct {
 	name     string
 	pkg      *Package
 	prog     *Program
-	Func     *ir.Function
+	Func     *ir.Func
 }

--- a/pkg/ast/FunctionNode.go
+++ b/pkg/ast/FunctionNode.go
@@ -55,10 +55,10 @@ type FunctionNode struct {
 	// itself and just reach into the Variants map to get the correct
 	// value for the function
 	NameCache string
-	Variants  map[string]*ir.Function // A mapping from mangled names to llvm functions
+	Variants  map[string]*ir.Func // A mapping from mangled names to llvm functions
 
 	Compiled bool
-	// CompiledValue  *ir.Function
+	// CompiledValue  *ir.Func
 
 	line   int
 	column int
@@ -98,7 +98,7 @@ func (n FunctionNode) Arguments(prog *Program) ([]*ir.Param, []types.Type, error
 // as external functions only need a declaration for their signature.
 // This function will generate the function object and push it to the map of other functions
 // in the program for use in calls
-func (n FunctionNode) Declare(prog *Program) (*ir.Function, error) {
+func (n FunctionNode) Declare(prog *Program) (*ir.Func, error) {
 	// Spawn a new scope
 	prog.ScopeDown(n.Token)
 
@@ -224,14 +224,14 @@ func (n FunctionNode) Codegen(prog *Program) (value.Value, error) {
 		if n.BodyParser != nil {
 			n.Body = n.BodyParser.parseBlockStmt()
 		}
-		var block *ir.BasicBlock
+		var block *ir.Block
 		var ok bool
 		gen, err := n.Body.Codegen(prog)
 		if err != nil {
 			return nil, err
 		}
 
-		if block, ok = gen.(*ir.BasicBlock); !ok {
+		if block, ok = gen.(*ir.Block); !ok {
 			return nil, fmt.Errorf("type assertion to block in function node failed")
 		}
 

--- a/pkg/ast/IdentNode.go
+++ b/pkg/ast/IdentNode.go
@@ -47,7 +47,7 @@ func NewIdentNode(name string) IdentNode {
 func (n IdentNode) NameString() string { return "IdentNode" }
 
 // GetFunc implements Callable.GetFunc
-func (n IdentNode) GetFunc(prog *Program, argTypes []types.Type) (*ir.Function, []value.Value, error) {
+func (n IdentNode) GetFunc(prog *Program, argTypes []types.Type) (*ir.Func, []value.Value, error) {
 
 	ns, nm := ParseName(n.String())
 	if ns == "" {
@@ -106,7 +106,7 @@ func (n IdentNode) Alloca(prog *Program) value.Value {
 }
 
 // Load returns a load instruction on a named reference with the given name
-func (n IdentNode) Load(block *ir.BasicBlock, prog *Program) *ir.InstLoad {
+func (n IdentNode) Load(block *ir.Block, prog *Program) *ir.InstLoad {
 	alloc := n.Alloca(prog)
 	if alloc == nil {
 		return nil

--- a/pkg/ast/LLVMComment.go
+++ b/pkg/ast/LLVMComment.go
@@ -30,8 +30,8 @@ func NewLLVMComment(format string, args ...interface{}) *LLVMComment {
 	}
 }
 
-// Def returns the LLVM syntax representation of the instruction.
-func (inst *LLVMComment) Def() string {
+// LLString returns the LLVM syntax representation of the instruction.
+func (inst *LLVMComment) LLString() string {
 	// Handle multi-line comments.
 	data := strings.Replace(inst.data, "\n", "; ", -1)
 	return fmt.Sprintf("; %s", data)

--- a/pkg/ast/LLVMIdent.go
+++ b/pkg/ast/LLVMIdent.go
@@ -13,7 +13,7 @@ import (
 // per operation
 type LLVMIdent struct {
 	// Parent basic block.
-	Parent *ir.BasicBlock
+	Parent *ir.Block
 
 	data string
 
@@ -60,11 +60,11 @@ func (inst *LLVMIdent) String() string {
 }
 
 // GetParent returns the parent basic block of the instruction.
-func (inst *LLVMIdent) GetParent() *ir.BasicBlock {
+func (inst *LLVMIdent) GetParent() *ir.Block {
 	return inst.Parent
 }
 
 // SetParent sets the parent basic block of the instruction.
-func (inst *LLVMIdent) SetParent(parent *ir.BasicBlock) {
+func (inst *LLVMIdent) SetParent(parent *ir.Block) {
 	inst.Parent = parent
 }

--- a/pkg/ast/LLVMRaw.go
+++ b/pkg/ast/LLVMRaw.go
@@ -11,7 +11,7 @@ import (
 // per operation
 type LLVMRaw struct {
 	// Parent basic block.
-	Parent *ir.BasicBlock
+	Parent *ir.Block
 
 	data string
 
@@ -58,11 +58,11 @@ func (inst *LLVMRaw) String() string {
 }
 
 // GetParent returns the parent basic block of the instruction.
-func (inst *LLVMRaw) GetParent() *ir.BasicBlock {
+func (inst *LLVMRaw) GetParent() *ir.Block {
 	return inst.Parent
 }
 
 // SetParent sets the parent basic block of the instruction.
-func (inst *LLVMRaw) SetParent(parent *ir.BasicBlock) {
+func (inst *LLVMRaw) SetParent(parent *ir.Block) {
 	inst.Parent = parent
 }

--- a/pkg/ast/Reference.go
+++ b/pkg/ast/Reference.go
@@ -15,5 +15,5 @@ type Reference interface {
 	Assignable
 
 	Alloca(*Program) value.Value
-	Load(*ir.BasicBlock, *Program) *ir.InstLoad
+	Load(*ir.Block, *Program) *ir.InstLoad
 }

--- a/pkg/ast/Scope.go
+++ b/pkg/ast/Scope.go
@@ -23,7 +23,7 @@ type Scope struct {
 	Vals        map[string]ScopeItem  `json:"values"`
 	Types       map[string]*ScopeType `json:"types"`
 	PackageName string                `json:"package_name"`
-	DebugInfo   *metadata.NamedDef
+	DebugInfo   *metadata.DISubprogram
 }
 
 // Add a value to this specific scope
@@ -266,7 +266,7 @@ const (
 // GenericTemplateScopeItem implements ScopeItem.
 // This is used so we can store functions in the scope (mainly in the root scope)
 type GenericTemplateScopeItem struct {
-	function *ir.Function
+	function *ir.Func
 	vis      Visibility
 	name     string
 	types    []TypeNode
@@ -320,7 +320,7 @@ func NewGenericTemplateScopeItem(name string) GenericTemplateScopeItem {
 // FunctionScopeItem implements ScopeItem.
 // This is used so we can store functions in the scope (mainly in the root scope)
 type FunctionScopeItem struct {
-	function *ir.Function
+	function *ir.Func
 	vis      Visibility
 	name     string
 	mangled  bool
@@ -363,7 +363,7 @@ func (item FunctionScopeItem) Node() Node {
 }
 
 // NewFunctionScopeItem constructs a function scope item
-func NewFunctionScopeItem(name string, node FunctionNode, function *ir.Function, vis Visibility) FunctionScopeItem {
+func NewFunctionScopeItem(name string, node FunctionNode, function *ir.Func, vis Visibility) FunctionScopeItem {
 	item := FunctionScopeItem{}
 	item.name = function.Name()
 	item.function = function

--- a/pkg/ast/SubscriptNode.go
+++ b/pkg/ast/SubscriptNode.go
@@ -97,7 +97,7 @@ func (n SubscriptNode) Alloca(prog *Program) value.Value {
 }
 
 // Load implements Reference.Load
-func (n SubscriptNode) Load(blk *ir.BasicBlock, prog *Program) *ir.InstLoad {
+func (n SubscriptNode) Load(blk *ir.Block, prog *Program) *ir.InstLoad {
 	ld, _ := n.Codegen(prog)
 	return ld.(*ir.InstLoad)
 }

--- a/pkg/ast/TypeInfoNode.go
+++ b/pkg/ast/TypeInfoNode.go
@@ -43,7 +43,7 @@ func (n TypeInfoNode) Codegen(prog *Program) (value.Value, error) {
 	typ, _ := n.Type(prog)
 
 	sct := typ.(*gtypes.StructType)
-	globl := prog.Module.NewGlobalDecl(fmt.Sprintf("type_info_%s", n.T), sct)
+	globl := prog.Module.NewGlobal(fmt.Sprintf("type_info_%s", n.T), sct)
 
 	globl.Init = constant.NewZeroInitializer(sct)
 
@@ -97,7 +97,7 @@ func (n TypeInfoNode) Alloca(prog *Program) value.Value {
 }
 
 // Load implements Reference.Load
-func (n TypeInfoNode) Load(blk *ir.BasicBlock, prog *Program) *ir.InstLoad {
+func (n TypeInfoNode) Load(blk *ir.Block, prog *Program) *ir.InstLoad {
 	return blk.NewLoad(n.Alloca(prog))
 }
 

--- a/pkg/ast/codegen.go
+++ b/pkg/ast/codegen.go
@@ -23,7 +23,7 @@ func mangleName(name string) string {
 	return fmt.Sprintf("%s_%d", name, nameNumber)
 }
 
-// func branchIfNoTerminator(blk *ir.BasicBlock, to *ir.BasicBlock) {
+// func branchIfNoTerminator(blk *ir.Block, to *ir.Block) {
 // 	if blk.Term == nil {
 // 		blk.NewBr(to)
 // 	}
@@ -59,8 +59,8 @@ func (n IfNode) Codegen(prog *Program) (value.Value, error) {
 	predicate = parentBlock.NewICmp(enum.IPredNE, zero, c)
 	parentFunc := parentBlock.Parent
 
-	var thenGenBlk *ir.BasicBlock
-	var endBlk *ir.BasicBlock
+	var thenGenBlk *ir.Block
+	var endBlk *ir.Block
 
 	thenBlk := parentFunc.NewBlock(mangleName(namePrefix + "then"))
 
@@ -69,12 +69,12 @@ func (n IfNode) Codegen(prog *Program) (value.Value, error) {
 		if gerr != nil {
 			return gerr
 		}
-		thenGenBlk = gen.(*ir.BasicBlock)
+		thenGenBlk = gen.(*ir.Block)
 		return nil
 	})
 
 	elseBlk := parentFunc.NewBlock(mangleName(namePrefix + "else"))
-	var elseGenBlk *ir.BasicBlock
+	var elseGenBlk *ir.Block
 
 	prog.Compiler.genInBlock(elseBlk, func() error {
 		// We only want to construct the else block if there is one.
@@ -83,7 +83,7 @@ func (n IfNode) Codegen(prog *Program) (value.Value, error) {
 			if gerr != nil {
 				return gerr
 			}
-			elseGenBlk, _ = gen.(*ir.BasicBlock)
+			elseGenBlk, _ = gen.(*ir.Block)
 		}
 		return nil
 	})
@@ -211,7 +211,7 @@ func (n WhileNode) Codegen(prog *Program) (value.Value, error) {
 	}
 	predicate = startblock.NewICmp(enum.IPredEQ, one, c)
 
-	var endBlk *ir.BasicBlock
+	var endBlk *ir.Block
 
 	bodyBlk := parentFunc.NewBlock(mangleName(namePrefix + "body"))
 	prog.Compiler.PushBlock(bodyBlk)
@@ -220,7 +220,7 @@ func (n WhileNode) Codegen(prog *Program) (value.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	bodyGenBlk := v.(*ir.BasicBlock)
+	bodyGenBlk := v.(*ir.Block)
 
 	// If there is no terminator for the block, IE: no return
 	// branch to the merge block
@@ -405,7 +405,7 @@ func newCharArray(s string) *constant.CharArray {
 
 // CreateEntryBlockAlloca - Create an alloca instruction in the entry block of
 // the function.  This is used for mutable variables etc.
-func createBlockAlloca(f *ir.Function, elemType types.Type, name string) *ir.InstAlloca {
+func createBlockAlloca(f *ir.Func, elemType types.Type, name string) *ir.InstAlloca {
 	// Create a new allocation in the root of the function
 	alloca := f.Blocks[0].NewAlloca(elemType)
 	// Set the name of the allocation (the variable name)
@@ -421,7 +421,7 @@ func codegenError(str string, args ...interface{}) value.Value {
 
 // BranchIfNoTerminator checks if the block has a terminator, and if it doesn't,
 // set it to a branch instead.
-func BranchIfNoTerminator(block, target *ir.BasicBlock) {
+func BranchIfNoTerminator(block, target *ir.Block) {
 	if block.Term == nil {
 		block.NewBr(target)
 	}

--- a/pkg/gtypes/size.go
+++ b/pkg/gtypes/size.go
@@ -86,9 +86,9 @@ func FloatByteCount(t *types.FloatType) int {
 		return 8
 	case types.FloatKindFP128:
 		return 16
-	case types.FloatKindX86FP80:
+	case types.FloatKindX86_FP80:
 		return 10
-	case types.FloatKindPPCFP128:
+	case types.FloatKindPPC_FP128:
 		return 16
 	default:
 		panic(fmt.Errorf("support for floating-point kind %q not yet implemented", t.Kind))
@@ -123,9 +123,9 @@ func FloatBitSize(t *types.FloatType) int {
 		return 64
 	case types.FloatKindFP128:
 		return 128
-	case types.FloatKindX86FP80:
+	case types.FloatKindX86_FP80:
 		return 80
-	case types.FloatKindPPCFP128:
+	case types.FloatKindPPC_FP128:
 		return 128
 	default:
 		panic(fmt.Errorf("support for floating-point kind %q not yet implemented", t.Kind))

--- a/pkg/lexer/Token.go
+++ b/pkg/lexer/Token.go
@@ -104,8 +104,9 @@ func (t Token) InferType() (types.Type, interface{}) {
 }
 
 // DILocation returns the string DILocation for debugging of this token
-func (t *Token) DILocation(scope *metadata.NamedDef) *metadata.DILocation {
+func (t *Token) DILocation(scope *metadata.DISubprogram) *metadata.DILocation {
 	return &metadata.DILocation{
+		MetadataID: -1, // unnamed. use as metadata literal.
 		// TODO: add t.source.Path?
 		Scope:  scope,
 		Line:   int64(t.Line),

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -28,7 +28,7 @@ func (v *VirtualMachine) String() string {
 // RunFunctionName runs a function in the virtual machine with arguments
 func (v *VirtualMachine) RunFunctionName(fnName string, args ...Value) (Value, error) {
 
-	var function *ir.Function
+	var function *ir.Func
 
 	for _, fn := range v.Module.Funcs {
 		if fn.Name() == fnName {
@@ -53,7 +53,7 @@ func (v *VirtualMachine) EvalInst(i ir.Instruction) {
 }
 
 // RunFunction runs a single function in the virtual machine's context
-func (v *VirtualMachine) RunFunction(fn *ir.Function, args ...Value) (Value, error) {
+func (v *VirtualMachine) RunFunction(fn *ir.Func, args ...Value) (Value, error) {
 
 	// go into a child scope for this function
 	v.Scope = v.Scope.SpawnChild()


### PR DESCRIPTION
The primary change is to use DISubprogram instead
of a named metadata definition to capturing the
scope in metadata debug info.

The other changes are just cleanups of llir in
preparation for the v0.3 release, e.g. rename
ir.BasicBlock to ir.Block and ir.Function to ir.Func.